### PR TITLE
Documentation of new features for 1.22 release.

### DIFF
--- a/src/resources/clb-devguide.xml
+++ b/src/resources/clb-devguide.xml
@@ -4036,6 +4036,18 @@
                             stream media over networks and is built on
                             top of UDP.</td>
                     </tr>
+                    <tr align="left">
+                        <td colspan="2">
+                            <code>TCP_STREAM</code></td>
+                        <td colspan="3">TCP Streaming allows either
+                            the client or server to send the first
+                            message when a connection is established.
+                            This option is for protocols where there is
+                            no request-response semantic. Either side of
+                            the connection can write the first message,
+                            with no response being necessarily
+                            required or expected.</td>
+                    </tr>
                 </tbody>
             </table>
             <wadl:resources

--- a/src/resources/samples/lb-list-protocols-response.json
+++ b/src/resources/samples/lb-list-protocols-response.json
@@ -70,6 +70,10 @@
         {
             "name": "SFTP",
             "port": 22
+        },
+        {
+            "name": "TCP_STREAM",
+            "port": 0
         }
     ]
 }

--- a/src/resources/samples/lb-list-protocols-response.xml
+++ b/src/resources/samples/lb-list-protocols-response.xml
@@ -17,4 +17,5 @@
     <protocol name="UDP" port="0" />
     <protocol name="UDP_STREAM" port="0" />
     <protocol name="SFTP" port="22" />
+    <protocol name="TCP_STREAM" port="0" />
 </protocols>

--- a/src/resources/wadl/common.ent
+++ b/src/resources/wadl/common.ent
@@ -498,10 +498,8 @@ content caching.</para>
     type="xsd:int">
     <wadl:doc xmlns="http://docbook.org/ns/docbook"
         xmlns:wadl="http://wadl.dev.java.net/2009/02" xml:lang="EN">
-        <para>Maximum number of connections allowed from a single IP
-            address in the defined <code>rateInterval</code>. To
-            enable an unlimited connection rate, set to 0. Otherwise,
-            set to a value from 1 to 100000.</para>
+        <para>Deprecated as of 1.22. Attribute can still be set,
+        but it has no effect on the load balancer.</para>
     </wadl:doc>
 </param>'>
 <!ENTITY maxConnectionsParameter '
@@ -519,10 +517,8 @@ content caching.</para>
     type="xsd:int">
     <wadl:doc xmlns="http://docbook.org/ns/docbook"
         xmlns:wadl="http://wadl.dev.java.net/2009/02" xml:lang="EN">
-        <para>Allow at least this number of connections per IP address
-            before applying throttling restrictions. Setting a value
-            of 0 allows unlimited simultaneous connections; otherwise,
-            set to a value from 1 to 1000.</para>
+        <para>Deprecated as of 1.22. Attribute can still be set,
+        but it has no effect on the load balancer.</para>
     </wadl:doc>
 </param>'>
 <!ENTITY rateIntervalParameter '
@@ -530,12 +526,8 @@ content caching.</para>
     type="xsd:int">
     <wadl:doc xmlns="http://docbook.org/ns/docbook"
         xmlns:wadl="http://wadl.dev.java.net/2009/02" xml:lang="EN">
-        <para>Frequency (in seconds) at which the
-                <code>maxConnectionRate</code> is assessed. For
-            example, a <code>maxConnectionRate</code> of 30 with a
-                <code>rateInterval</code> of 60 would allow a maximum
-            of 30 connections per minute for a single IP address. Set
-            to a value from 1 to 3600.</para>
+        <para>Deprecated as of 1.22. Attribute can still be set,
+        but it has no effect on the load balancer.</para>
     </wadl:doc>
 </param>' >
 <!ENTITY persistenceTypeParameter '


### PR DESCRIPTION
Added TCP Streaming protocol, and deprecated the maxConnectionRate, minConnections, and rateInterval attributes from Connection Throttling.
