### PR TITLE
Create a Travis build that submits to staging.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+---
+language: python
+python:
+- "3.4"
+env:
+- CONTENT_ID_BASE=https://github.com/rackerlabs/docs-cloud-load-balancers
+- CONTENT_STORE_URL=http://104.130.43.81:8000/
+- DESC=staging
+- secure: "Nr1KMW/SMFF2Z6BU24S/eYMDEL3uk7ha3Wzc+p6CSZyTEaoD6Bfba6cxhqFreDbmaZ2yQ08mbtCIO0/HrXX50rln0yPVJy17byNdd8+HZr0AwHVbcNz2jLrU+D6hb+gAzgNg3ggTrJkl66q3mq1g9JQW0fjkOIZa9lB11/073b0="
+- secure: "FnT11drPJhMJhWBhlEERX+j4MBiUA/Q/xuO9D8CrsL6qR5wZTOR/sgOeS/VLEUlzF+d3Z4W0z6XydV0v8HrIz8AH9e/U7Dy1lOLHl2I9vK9FE9XunpS1CBDF6TkSxJRUbsLFc1A/I65npjZWOdAGkDuMwBrAHArtVaZSj/LuUcE="
+- secure: "Hpy6ALIamYvFTFVKxdNGpbQzV9LK+BEYVU4ntbAEq1Tf5OwOI4HPI8Dsz7PiEKl8n8IpH8HwUdBef3XcDw4a6BP8JtWshgcf3773IrMHYmRr0929Bj9SVDFAuc5UwuqCQ9kUjCd6nXck1Z0rYt+f40ktHBV4NyI4M6TfVcief1I="
+install:
+- pip install -e git+https://github.com/deconst/preparer-sphinx.git#egg=deconstrst
+script:
+- 'echo "Submitting content: ${DESC:-nowhere}"'
+- export CONTENT_STORE_APIKEY=${SKEY1}${SKEY2}${SKEY3}
+- deconst-preparer-sphinx

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: python
 python:
 - "3.4"
+sudo: false
 env:
 - CONTENT_ID_BASE=https://github.com/rackerlabs/docs-cloud-load-balancers
 - CONTENT_STORE_URL=http://104.130.43.81:8000/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ install:
 script:
 - 'echo "Submitting content: ${DESC:-nowhere}"'
 - export CONTENT_STORE_APIKEY=${SKEY1}${SKEY2}${SKEY3}
+- cd rst/dev-guide
 - deconst-preparer-sphinx

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ python:
 - "3.4"
 sudo: false
 env:
-- CONTENT_ID_BASE=https://github.com/rackerlabs/docs-cloud-load-balancers
-- CONTENT_STORE_URL=http://104.130.43.81:8000/
-- DESC=staging
-- secure: "Nr1KMW/SMFF2Z6BU24S/eYMDEL3uk7ha3Wzc+p6CSZyTEaoD6Bfba6cxhqFreDbmaZ2yQ08mbtCIO0/HrXX50rln0yPVJy17byNdd8+HZr0AwHVbcNz2jLrU+D6hb+gAzgNg3ggTrJkl66q3mq1g9JQW0fjkOIZa9lB11/073b0="
-- secure: "FnT11drPJhMJhWBhlEERX+j4MBiUA/Q/xuO9D8CrsL6qR5wZTOR/sgOeS/VLEUlzF+d3Z4W0z6XydV0v8HrIz8AH9e/U7Dy1lOLHl2I9vK9FE9XunpS1CBDF6TkSxJRUbsLFc1A/I65npjZWOdAGkDuMwBrAHArtVaZSj/LuUcE="
-- secure: "Hpy6ALIamYvFTFVKxdNGpbQzV9LK+BEYVU4ntbAEq1Tf5OwOI4HPI8Dsz7PiEKl8n8IpH8HwUdBef3XcDw4a6BP8JtWshgcf3773IrMHYmRr0929Bj9SVDFAuc5UwuqCQ9kUjCd6nXck1Z0rYt+f40ktHBV4NyI4M6TfVcief1I="
+  global:
+  - CONTENT_ID_BASE=https://github.com/rackerlabs/docs-cloud-load-balancers
+  - CONTENT_STORE_URL=http://104.130.43.81:8000/
+  - DESC=staging
+  - secure: "Nr1KMW/SMFF2Z6BU24S/eYMDEL3uk7ha3Wzc+p6CSZyTEaoD6Bfba6cxhqFreDbmaZ2yQ08mbtCIO0/HrXX50rln0yPVJy17byNdd8+HZr0AwHVbcNz2jLrU+D6hb+gAzgNg3ggTrJkl66q3mq1g9JQW0fjkOIZa9lB11/073b0="
+  - secure: "FnT11drPJhMJhWBhlEERX+j4MBiUA/Q/xuO9D8CrsL6qR5wZTOR/sgOeS/VLEUlzF+d3Z4W0z6XydV0v8HrIz8AH9e/U7Dy1lOLHl2I9vK9FE9XunpS1CBDF6TkSxJRUbsLFc1A/I65npjZWOdAGkDuMwBrAHArtVaZSj/LuUcE="
+  - secure: "Hpy6ALIamYvFTFVKxdNGpbQzV9LK+BEYVU4ntbAEq1Tf5OwOI4HPI8Dsz7PiEKl8n8IpH8HwUdBef3XcDw4a6BP8JtWshgcf3773IrMHYmRr0929Bj9SVDFAuc5UwuqCQ9kUjCd6nXck1Z0rYt+f40ktHBV4NyI4M6TfVcief1I="
 install:
 - pip install -e git+https://github.com/deconst/preparer-sphinx.git#egg=deconstrst
 script:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Rackspace Cloud Load Balancers API documentation
 
+[![Build Status](https://travis-ci.org/rackerlabs/docs-cloud-load-balancers.svg?branch=master)](https://travis-ci.org/rackerlabs/docs-cloud-load-balancers)
+
 ## Resources
 
 This github repository contains the source files for the following Rackspace Cloud Load Balancers API documentation:
@@ -50,4 +52,3 @@ The files that are most likely to be of interest are:
 If you want to make changes to the example files referenced in the WADL file, you can find the example files at [src/resources/samples](src/resources/samples).
 
 The status codes referenced by the WADL files are at [src/resources/wadl/common.ent](src/resources/wadl/common.ent).
-


### PR DESCRIPTION
I had to split the API key into three parts and reconstitute it in the build.

When this is ready to deploy to production, I can use the same strategy that I did in rackerlabs/docs-core-infra-user-guide@622d2f1 to set up the build matrix properly.