### PR TITLE
Update directory path to _build in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .DS_Store
 target/
 doctrees/
-rst/dev-guide/_build
+api-docs/cloud-load-balancer-v1/_build
+api-docs/cloud-load-balancer-v2/_build
 !.gitignore
 *.iml
 *.iws


### PR DESCRIPTION
So -build directory will be ignored for both versions 1 and 2. New paths are:

api-docs/cloud-load-balancer-v1/_build
api-docs/cloud-load-balancer-v2/_build