### PR TITLE
Update the build to include v2 as well

### DIFF
--- a/api-docs/cloud-load-balancers-v2/_deconst.json
+++ b/api-docs/cloud-load-balancers-v2/_deconst.json
@@ -1,3 +1,8 @@
 {
-  "contentIDBase": "https://github.com/rackerlabs/docs-cloud-load-balancers/"
+  "contentIDBase": "https://github.com/rackerlabs/docs-cloud-load-balancers/v2/",
+  "githubUrl": "https://github.com/rackerlabs/docs-cloud-load-balancers/",
+  "githubBranch": "master",
+  "meta": {
+    "preferGithubIssues": false
+  }
 }

--- a/script/cibuild
+++ b/script/cibuild
@@ -14,3 +14,6 @@ fi
 
 cd api-docs/cloud-load-balancers-v1
 deconst-preparer-sphinx
+
+cd ../cloud-load-balancers-v2
+deconst-preparer-sphinx


### PR DESCRIPTION
Corrects the v2 directory's `_deconst.json` file and modifies `script/cibuild` to build both v1 and v2 docs.