### PR TITLE
Update _build pattern match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 target/
-_build/*
+_build/
 doctrees/*
 api-docs/cloud-load-balancer-v1/_build/*
 api-docs/cloud-load-balancer-v2/_build/*


### PR DESCRIPTION
Per help from Ash and Keith -- If we specify either of the following patterns, all occurrences of ``_build`` directory in repo will be ignored.

``_build/``   or ``**/_build/``