### PR TITLE
Update _deconst.json to link to "Submit an issue"

### DIFF
--- a/api-docs/cloud-load-balancers-v2/_deconst.json
+++ b/api-docs/cloud-load-balancers-v2/_deconst.json
@@ -3,6 +3,6 @@
   "githubUrl": "https://github.com/rackerlabs/docs-cloud-load-balancers/",
   "githubBranch": "master",
   "meta": {
-    "preferGithubIssues": false
+    "preferGithubIssues": true
   }
 }


### PR DESCRIPTION
rather than "Edit on GitHub".

Since we use the singlehtml template, Edit on Github always opens the index.rst file. Doesn't help people by opening the source file for current location. Changing link to Submit and Issue. When people click, they go to issues page where they can create a new issue.