### PR TITLE
Fix broken links in common section - Sending API requests 

### DIFF
--- a/api-docs/cloud-load-balancers-v1/common-gs/how-to-use-curl.rst
+++ b/api-docs/cloud-load-balancers-v1/common-gs/how-to-use-curl.rst
@@ -13,7 +13,7 @@ linux-based operating system, copy each example directly to the command line or 
 
    If you are on Microsoft Windows®, you need to make adjustments to the cURL examples in
    order to run them. See
-   :ref:`Convert cURL examples to run on Windows :ref:`<convert-cURL-examples-for-windows>`
+   :ref:`Convert cURL examples to run on Windows<convert-cURL-examples-for-windows>`.
 
 
 .. _auth-curl-json:
@@ -124,11 +124,9 @@ If you do not want to pretty-print JSON output, omit this code.
    the API service will return an error.
 
 
-.. _json encoder and decoder: http://docs.python.org/2/library/json.html
-.. _simplejson encoder and decoder: http://simplejson.googlecode.com/svn/tags/simplejson-2.0.9/docs/index.html
+.. _JSON encoder and decoder: http://docs.python.org/2/library/json.html
+.. _simplejson encoder and decoder: https://simplejson.readthedocs.io/en/latest/
 
-.. _json.tool: http://docs.python.org/2/library/json.html
-.. _simplejson.tool: http://simplejson.googlecode.com/svn/tags/simplejson-2.0.9/docs/index.html
 
 
 .. _convert-cURL-examples-for-windows:

--- a/api-docs/cloud-load-balancers-v1/getting-started/send-request-ovw.rst
+++ b/api-docs/cloud-load-balancers-v1/getting-started/send-request-ovw.rst
@@ -8,7 +8,7 @@ This section shows how to send requests by using cURL.
 .. note::
      You can also use Rackspace Cloud API services by using the following methods:
 
-     -  If you are developing applications or automation, try using `Rackspace SDKs`_, the
+     -  If you are developing applications or automation, try using :rax-devdocs:`Rackspace SDKs <#sdks>`, the
         `Rackspace CLI`_, or `OpenStack client applications`_.
 
      -  For API development, testing and workflow management in a graphical environment, try
@@ -19,7 +19,6 @@ This section shows how to send requests by using cURL.
 .. include:: ../common-gs/how-to-use-curl.rst
 
 .. _cURL command line tool: http://curl.haxx.se/
-.. _Rackspace SDKs: https://developer.rackspace.com/sdks/
 .. _Rackspace CLI: https://developer.rackspace.com/docs/rack-cli/
 .. _Openstack client applications: https://wiki.openstack.org/wiki/OpenStackClients
 .. _Postman: http://www.getpostman.com


### PR DESCRIPTION
Fixed link to Rackspace SDKs and to simplejson encoder and decoder.