### PR TITLE
For v2, update get-credentials.rst to remove outdated screenshot

### DIFF
--- a/api-docs/cloud-load-balancers-v2/common-gs/auth-using-curl.rst
+++ b/api-docs/cloud-load-balancers-v2/common-gs/auth-using-curl.rst
@@ -7,6 +7,11 @@ Follow these steps to authenticate to the Rackspace Cloud by
 - :ref:`Review the authentication response <review-auth-resp>`
 - :ref:`Configure environment variables <configure-environment-variables>`
 
+.. important::
+
+   The cURL examples in this guide are provided for reference only. Because
+   the use of cURL has environmental dependencies, copying and pasting the
+   examples might not work in your environment.
 
 .. _send-auth-req-curl:
 

--- a/api-docs/cloud-load-balancers-v2/common-gs/get-credentials.rst
+++ b/api-docs/cloud-load-balancers-v2/common-gs/get-credentials.rst
@@ -5,39 +5,26 @@ Get your credentials
 ====================
 
 To communicate with Rackspace Cloud services by using the REST API, you need
-your Rackspace Cloud account username, API key, and account number. To get
-this information, log in to the :mycloud:`Rackspace Cloud Control Panel<>`.
+your Rackspace Cloud account username, API key, and account number.
 
 .. note::
-     In the API service documentation, the account number is referred to as
+     In the API documentation, the account number is referred to as
      your *tenant ID* or *tenant name*.
 
-After you log in, click your username on the upper-right side of the top
-navigation pane. Then, select **Account Settings** to open the page.
+To get this information, log in to the
+:mycloud:`Rackspace Cloud Control Panel<>`.
 
-.. image:: ../common-gs/images/show-api-key-control-panel.png
+-  Your account username is the username that you use to log in.
 
-Save your API key
-~~~~~~~~~~~~~~~~~
+-  To get your account number, click the **username** menu in the top-right
+   corner of the control panel. The account number is shown at the top of the
+   menu.
 
-#. On the Account Settings page, find the **API Key** field in the
-   **Login Details**
-   section.
-#. Click **Show** to see the key value, and then copy it to a text editor
-   of your choice.
-#. Click **Hide** to secure the API key value in the browser.
+-  To get your API key, follow the instructions in
+   :how-to:`View and reset your API key <view-and-reset-your-api-key>`.
 
 .. important::
       Protect your API key. Do not expose the value in code samples, screen
       captures, or insecure client-server communications. Also, ensure that
-      the value is not
-      included in source code that is stored in public repositories.
-
-Save your account number
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-#. On the Account Settings page, scroll down to the **Account Details**
-   section.
-
-#. Copy and save the account number.
-
+      the value is not included in source code that is stored in public
+      repositories.

--- a/api-docs/cloud-load-balancers-v2/common-gs/how-to-use-curl.rst
+++ b/api-docs/cloud-load-balancers-v2/common-gs/how-to-use-curl.rst
@@ -13,9 +13,14 @@ or a script.
 .. note::
 
    If you are using Microsoft Windows, you need to adjust the cURL examples to
-   run them. See
-   :ref:`Convert cURL examples to run on Windows<convert-cURL-examples-for-windows>`.
+   run them. See :ref:`Convert cURL examples to run on Windows
+   <convert-cURL-examples-for-windows>`.
 
+.. important::
+
+   The cURL examples in this guide are provided for reference only. Because
+   the use of cURL has environmental dependencies, copying and pasting the
+   examples might not work in your environment.
 
 .. _auth-curl-json:
 


### PR DESCRIPTION
and add note to auth-using-curl.rst and how-to-use-curl.rst that
examples are for reference only

https://github.com/rackerlabs/docs-rackspace/issues/282

