### PR TITLE
Reganm fix get show logging

### DIFF
--- a/api-docs/cloud-load-balancers-v1/api-reference/methods/get-show-connection-logging-configuration-v1.0-account-loadbalancers-loadbalancerid-connectionlogging.rst
+++ b/api-docs/cloud-load-balancers-v1/api-reference/methods/get-show-connection-logging-configuration-v1.0-account-loadbalancers-loadbalancerid-connectionlogging.rst
@@ -52,6 +52,9 @@ The log format will be as follows.
 
 **Log format for HTTP type load balancer instances:**
 
+.. note::
+   A load balancer with SSL termination enabled is an HTTP type load balancer.
+
 ``%v %{Host}i %h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\" %n``
 
 .. list-table::

--- a/api-docs/cloud-load-balancers-v1/api-reference/methods/get-show-connection-logging-configuration-v1.0-account-loadbalancers-loadbalancerid-connectionlogging.rst
+++ b/api-docs/cloud-load-balancers-v1/api-reference/methods/get-show-connection-logging-configuration-v1.0-account-loadbalancers-loadbalancerid-connectionlogging.rst
@@ -14,7 +14,7 @@ Shows the connection logging configuration.
 
 The log format will be as follows.
 
-**Log format for HTTP type load balancer instances:**
+**Log format for HTTPS type load balancer instances:**
 
 ``%v %t %h %A:%p %n %B %b %T``
 
@@ -44,13 +44,13 @@ The log format will be as follows.
      - Time from initiating request to backend node until the first byte of the
        response is received, in seconds.
 
-**Sample log line for HTTP type load balancer instances:**
+**Sample log line for HTTPS type load balancer instances:**
 
 .. code::
 
    123456_78910 [14/Oct/2015:18:17:05 +0000] 192.168.2.101 10.50.4.5:443 10.50.4.82:443 1337 2183 0.001282
 
-**Log format for HTTPS type load balancer instances:**
+**Log format for HTTP type load balancer instances:**
 
 ``%v %{Host}i %h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-Agent}i\" %n``
 
@@ -85,7 +85,7 @@ The log format will be as follows.
    * - ``%n``
      - Node that was used for the connection.
 
-**Sample log lines for HTTPS type load balancer instances:**
+**Sample log lines for HTTP type load balancer instances:**
 
 .. code::
 


### PR DESCRIPTION
…ancers-loadbalancerid-connectionlogging.rst

HTTP and HTTPS logging examples and formats have their labeling reversed. HTTPS encryption prevents the load balancer from being able to read the http content contained in the traffic at that point, so only HTTP lb instances will log the first line of the request (%r), user agents (%{User-Agent}i), etc. I also added a suggested note for clarifying that LBs with SSL termination, rather than end-to-end encryption, count as HTTP type load balancers and will have the same type of logging.