### PR TITLE
removed sentence from create or update access list

### DIFF
--- a/api-docs/cloud-load-balancers-v1/api-reference/methods/post-create-or-update-access-list-v1.0-account-loadbalancers-loadbalancerid-accesslist.rst
+++ b/api-docs/cloud-load-balancers-v1/api-reference/methods/post-create-or-update-access-list-v1.0-account-loadbalancers-loadbalancerid-accesslist.rst
@@ -76,7 +76,6 @@ The following table shows the URI parameters for the request:
 |                          |                         |balancer.                |
 +--------------------------+-------------------------+-------------------------+
 
-This operation does not accept a request body.
 
 **Example Create or update access list: JSON request**
 


### PR DESCRIPTION
I was only able to find the error on the Create or update access list, I did not see it for update health monitor. After talking to Madhavi Reddy it appears the other error may have already been fixed in a previous ticket. 