### PR TITLE
Replaced: Polyfill

### DIFF
--- a/api-docs/cloud-load-balancers-v1/_templates/scripts.html
+++ b/api-docs/cloud-load-balancers-v1/_templates/scripts.html
@@ -121,5 +121,5 @@
 </script>
 <script src="https://docs.rackspace.com/assets/bundle.js"></script>
 <script
-    src="https://polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
+    src="https://polyfill-fastly.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
 </script>


### PR DESCRIPTION
@the2hill 

GitHub url link: https://developer.rackspace.com/docs/cloud-load-balancers/v1/ maps correctly to https://docs-ospc.rackspace.com/cloud-load-balancers/v1/.

Please review and merge PR.